### PR TITLE
add hello_world to avoid package error in go get

### DIFF
--- a/hello_world.go
+++ b/hello_world.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World!")
+}


### PR DESCRIPTION
re: page 2 of book: `go get github.com/shapeshed/golang-book-examples`
throws  message `can't load package: package github.com/shapeshed/golang-book-examples: no Go files` 

Files download ok but new users may not understand this error can be ignored.
Adding a minimal hello world eliminates the error.